### PR TITLE
fix bits_to_bytes

### DIFF
--- a/eciton_sdk/src/bitops.rs
+++ b/eciton_sdk/src/bitops.rs
@@ -17,8 +17,9 @@
 //! Contain bit operations declarations.
 
 use core::{
-    ops::{BitAnd, Shl, Not, BitAndAssign, BitOrAssign},
-    cmp::PartialOrd, mem::size_of
+    cmp::PartialOrd,
+    mem::size_of,
+    ops::{BitAnd, BitAndAssign, BitOrAssign, Not, Shl},
 };
 
 /// Number of bits per byte.
@@ -34,7 +35,7 @@ pub const BITS_PER_BYTE: usize = 8;
 #[inline(always)]
 pub const fn bits_to_bytes(n: usize) -> usize {
     // Assuming that a byte contains 8 bits.
-    (n + 7) << 0x3
+    (n + 7) >> 0x3
 }
 
 /// Convert bytes to bits.
@@ -70,7 +71,7 @@ pub const fn bits_per_type<T>() -> usize {
 #[inline(always)]
 pub fn set_bit<T>(value: &mut T, pos: usize)
 where
-    T: BitOrAssign + Shl<usize, Output = T> + From<u8>
+    T: BitOrAssign + Shl<usize, Output = T> + From<u8>,
 {
     let mask = T::from(1u8) << pos;
     *value |= mask;
@@ -84,7 +85,7 @@ where
 #[inline(always)]
 pub fn clear_bit<T>(value: &mut T, pos: usize)
 where
-    T: BitAndAssign + Shl<usize, Output = T> + Not<Output = T> + From<u8>
+    T: BitAndAssign + Shl<usize, Output = T> + Not<Output = T> + From<u8>,
 {
     let mask = !(T::from(1u8) << pos);
     *value &= mask;
@@ -98,9 +99,9 @@ where
 #[inline(always)]
 pub fn test_bit<T>(value: &T, pos: usize) -> bool
 where
-    T: BitAndAssign + Shl<usize, Output = T> + BitAnd<Output = T>
-    + From<u8> + Copy + PartialOrd
+    T: BitAndAssign + Shl<usize, Output = T> + BitAnd<Output = T> + From<u8> + Copy + PartialOrd,
 {
     let mask = T::from(1u8) << pos;
     (*value & mask) != T::from(0u8)
 }
+


### PR DESCRIPTION
```rust
#[inline(always)]
pub const fn bits_to_bytes(n: usize) -> usize {
    (n + 7) << 0x3
}
```
(n + 7) << 0x3 == (n + 7) * 8 -> bits_to_bytes(20) == 216

(n + 7) >> 0x3 == (n + 7) / 8 -> bits_to_bytes(20) == 3
